### PR TITLE
add more context to times and markdown rendering to location

### DIFF
--- a/views/card.js
+++ b/views/card.js
@@ -23,10 +23,11 @@ module.exports = function gatheringCard (opts) {
 
     const { title, description, startDateTime, image } = state
     const background = image && image.link ? `url('${blobUrl(imageString(image))}')` : ''
-    var date
+    var date, humanReadableDiff
     if (startDateTime && startDateTime.epoch) {
       const t = spacetime(startDateTime.epoch)
       date = `${t.format('date')} ${t.format('month-short')}`
+      humanReadableDiff = spacetime.now().since(t)
     }
 
     return [
@@ -40,7 +41,10 @@ module.exports = function gatheringCard (opts) {
           }
         },
         [
-          h('div', date)
+          h('div', [
+            date,
+            h('div.humanTime', humanReadableDiff.rounded)
+          ])
         ]
       )
     ]

--- a/views/card.js
+++ b/views/card.js
@@ -23,12 +23,14 @@ module.exports = function gatheringCard (opts) {
 
     const { title, description, startDateTime, image } = state
     const background = image && image.link ? `url('${blobUrl(imageString(image))}')` : ''
-    var date, humanReadableDiff
+
+    var date, t
     if (startDateTime && startDateTime.epoch) {
-      const t = spacetime(startDateTime.epoch)
+      t = spacetime(startDateTime.epoch)
       date = `${t.format('date')} ${t.format('month-short')}`
-      humanReadableDiff = spacetime.now().since(t).rounded
     }
+
+    const relativeTimeToEvent = Value(showRelativeTime(t))
 
     return [
       h('div.details', [
@@ -38,15 +40,21 @@ module.exports = function gatheringCard (opts) {
           style: {
             'background-image': background,
             'background-color': color(gathering.key)
-          }
+          },
+          'title': relativeTimeToEvent,
+          'ev-mouseenter': () => relativeTimeToEvent.set(showRelativeTime(t))
         },
         [
-          h('div', [
-            date,
-            h('div.humanTime', humanReadableDiff)
-          ])
+          h('div', date)
         ]
       )
     ]
   }))
+}
+
+function showRelativeTime(t) {
+    if (t) {
+      return spacetime.now().since(t).rounded
+    }
+    return ''
 }

--- a/views/card.js
+++ b/views/card.js
@@ -30,7 +30,7 @@ module.exports = function gatheringCard (opts) {
       date = `${t.format('date')} ${t.format('month-short')}`
     }
 
-    const relativeTimeToEvent = Value(showRelativeTime(t))
+    const relativeTimeToEvent = Value(getRelativeTime(t))
 
     return [
       h('div.details', [
@@ -42,7 +42,7 @@ module.exports = function gatheringCard (opts) {
             'background-color': color(gathering.key)
           },
           'title': relativeTimeToEvent,
-          'ev-mouseenter': () => relativeTimeToEvent.set(showRelativeTime(t))
+          'ev-mouseenter': () => relativeTimeToEvent.set(getRelativeTime(t))
         },
         [
           h('div', date)
@@ -52,9 +52,9 @@ module.exports = function gatheringCard (opts) {
   }))
 }
 
-function showRelativeTime(t) {
-    if (t) {
-      return spacetime.now().since(t).rounded
-    }
-    return ''
+function getRelativeTime (t) {
+  if (t) {
+    return spacetime.now().since(t).rounded
+  }
+  return ''
 }

--- a/views/card.js
+++ b/views/card.js
@@ -27,7 +27,7 @@ module.exports = function gatheringCard (opts) {
     if (startDateTime && startDateTime.epoch) {
       const t = spacetime(startDateTime.epoch)
       date = `${t.format('date')} ${t.format('month-short')}`
-      humanReadableDiff = spacetime.now().since(t)
+      humanReadableDiff = spacetime.now().since(t).rounded
     }
 
     return [
@@ -43,7 +43,7 @@ module.exports = function gatheringCard (opts) {
         [
           h('div', [
             date,
-            h('div.humanTime', humanReadableDiff.rounded)
+            h('div.humanTime', humanReadableDiff)
           ])
         ]
       )

--- a/views/card.mcss
+++ b/views/card.mcss
@@ -35,10 +35,15 @@ GatheringCard {
     justify-content: center
 
     div {
+      text-align:center
       color: #fff
       font-weight: 600
       font-size: 3rem
       text-shadow: rgba(0, 0, 0, 0.46) 0 0 10px
+
+      div.humanTime {
+        font-size: 1.5rem
+      }
     }
   }
 }

--- a/views/show.js
+++ b/views/show.js
@@ -46,7 +46,7 @@ module.exports = function GatheringShow (opts) {
       ]),
       h('section.spacetime', [
         startDateTime && startDateTime.epoch ? [ h('label', 'time'), Time(new Date(startDateTime.epoch)) ] : null,
-        location ? [ h('label', 'location'), h('div.location', location) ] : null
+        location ? [ h('label', 'location'), h('div.location', markdown(location)) ] : null
       ]),
       h('section.attendance', [
         h('div.attendanceButtons', [
@@ -120,8 +120,9 @@ module.exports = function GatheringShow (opts) {
 
 function Time (date) {
   const t = spacetime(date)
+
   return h('div.time', [
-    t.format('nice'),
+    t.format('nice-day'),
     h('div.zone', { title: 'timezone' }, [
       getTimezone() || '??',
       h('span', ['(UTC ', getTimezoneOffset(), ')'])


### PR DESCRIPTION
This pull request does the following changes
 - add markdown rendering to location
 - adds a relative time in the card view
 - adds the day of the event in the gathering view

screenshot of card view
![image](https://user-images.githubusercontent.com/513457/49425206-fde39000-f7c4-11e8-8dd1-8041dca98945.png)
